### PR TITLE
Fix Crashes of Scans with long Names

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -13,6 +13,7 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
+COPY utils/ utils/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o manager main.go

--- a/operator/controllers/execution/scan_controller.go
+++ b/operator/controllers/execution/scan_controller.go
@@ -116,7 +116,6 @@ func (r *ScanReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 		err = r.setHookStatus(&scan)
 	case "ReadAndWriteHookProcessing":
 		err = r.executeReadAndWriteHooks(&scan)
-
 	case "ReadAndWriteHookCompleted":
 		err = r.startReadOnlyHooks(&scan)
 	case "ReadOnlyHookProcessing":
@@ -129,21 +128,6 @@ func (r *ScanReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	return ctrl.Result{}, nil
 }
 
-func (r *ScanReconciler) getJob(name, namespace string) (*batch.Job, error) {
-	ctx := context.Background()
-
-	var job batch.Job
-	err := r.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, &job)
-	if apierrors.IsNotFound(err) {
-		return nil, nil
-	} else if err != nil {
-		r.Log.Error(err, "unable to get job")
-		return nil, err
-	}
-
-	return &job, nil
-}
-
 type jobCompletionType string
 
 const (
@@ -153,22 +137,51 @@ const (
 	unknown    jobCompletionType = "Unknown"
 )
 
-func (r *ScanReconciler) checkIfJobIsCompleted(name, namespace string) (jobCompletionType, error) {
-	job, err := r.getJob(name, namespace)
+func allJobsCompleted(jobs *batch.JobList) jobCompletionType {
+	hasCompleted := true
+
+	for _, job := range jobs.Items {
+		if job.Status.Failed > 0 {
+			return failed
+		} else if job.Status.Succeeded == 0 {
+			hasCompleted = false
+		}
+	}
+
+	if hasCompleted {
+		return completed
+	}
+	return incomplete
+}
+
+func (r *ScanReconciler) getJobsForScan(scan *executionv1.Scan, labels client.MatchingLabels) (*batch.JobList, error) {
+	ctx := context.Background()
+
+	// check if k8s job for scan was already created
+	var jobs batch.JobList
+	if err := r.List(
+		ctx,
+		&jobs,
+		client.InNamespace(scan.Namespace),
+		client.MatchingField(ownerKey, scan.Name),
+		labels,
+	); err != nil {
+		r.Log.Error(err, "Unable to list child jobs")
+		return nil, err
+	}
+
+	return &jobs, nil
+}
+
+func (r *ScanReconciler) checkIfJobIsCompleted(scan *executionv1.Scan, labels client.MatchingLabels) (jobCompletionType, error) {
+	jobs, err := r.getJobsForScan(scan, labels)
 	if err != nil {
 		return unknown, err
 	}
-	if job == nil {
-		return unknown, errors.New("Both Job and error were nil. This isn't really expected")
-	}
 
-	if job.Status.Succeeded != 0 {
-		return completed, nil
-	}
-	if job.Status.Failed != 0 {
-		return failed, nil
-	}
-	return unknown, nil
+	r.Log.V(9).Info("Got related jobs", "count", len(jobs.Items))
+
+	return allJobsCompleted(jobs), nil
 }
 
 // Helper functions to check and remove string from a slice of strings.
@@ -220,11 +233,11 @@ func (r *ScanReconciler) startScan(scan *executionv1.Scan) error {
 	namespacedName := fmt.Sprintf("%s/%s", scan.Namespace, scan.Name)
 	log := r.Log.WithValues("scan_init", namespacedName)
 
-	job, err := r.getJob(fmt.Sprintf("scan-%s", scan.Name), scan.Namespace)
+	jobs, err := r.getJobsForScan(scan, client.MatchingLabels{"experimental.securecodebox.io/job-type": "scanner"})
 	if err != nil {
 		return err
 	}
-	if job != nil {
+	if len(jobs.Items) > 0 {
 		log.V(8).Info("Job already exists. Doesn't need to be created.")
 		return nil
 	}
@@ -267,7 +280,7 @@ func (r *ScanReconciler) startScan(scan *executionv1.Scan) error {
 		rules,
 	)
 
-	job, err = r.constructJobForScan(scan, &scanType)
+	job, err := r.constructJobForScan(scan, &scanType)
 	if err != nil {
 		log.Error(err, "unable to create job object ScanType")
 		return err
@@ -296,7 +309,7 @@ func (r *ScanReconciler) startScan(scan *executionv1.Scan) error {
 func (r *ScanReconciler) checkIfScanIsCompleted(scan *executionv1.Scan) error {
 	ctx := context.Background()
 
-	status, err := r.checkIfJobIsCompleted(fmt.Sprintf("scan-%s", scan.Name), scan.Namespace)
+	status, err := r.checkIfJobIsCompleted(scan, client.MatchingLabels{"experimental.securecodebox.io/job-type": "scanner"})
 	if err != nil {
 		return err
 	}
@@ -326,11 +339,11 @@ func (r *ScanReconciler) startParser(scan *executionv1.Scan) error {
 	namespacedName := fmt.Sprintf("%s/%s", scan.Namespace, scan.Name)
 	log := r.Log.WithValues("scan_parse", namespacedName)
 
-	job, err := r.getJob(fmt.Sprintf("parse-%s", scan.Name), scan.Namespace)
+	jobs, err := r.getJobsForScan(scan, client.MatchingLabels{"experimental.securecodebox.io/job-type": "parser"})
 	if err != nil {
 		return err
 	}
-	if job != nil {
+	if len(jobs.Items) > 0 {
 		log.V(8).Info("Job already exists. Doesn't need to be created.")
 		return nil
 	}
@@ -384,7 +397,7 @@ func (r *ScanReconciler) startParser(scan *executionv1.Scan) error {
 	labels["experimental.securecodebox.io/job-type"] = "parser"
 	automountServiceAccountToken := true
 	var backOffLimit int32 = 3
-	job = &batch.Job{
+	job := &batch.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: make(map[string]string),
 			Name:        fmt.Sprintf("parse-%s", scan.Name),
@@ -459,7 +472,7 @@ func (r *ScanReconciler) startParser(scan *executionv1.Scan) error {
 func (r *ScanReconciler) checkIfParsingIsCompleted(scan *executionv1.Scan) error {
 	ctx := context.Background()
 
-	status, err := r.checkIfJobIsCompleted(fmt.Sprintf("parse-%s", scan.Name), scan.Namespace)
+	status, err := r.checkIfJobIsCompleted(scan, client.MatchingLabels{"experimental.securecodebox.io/job-type": "parser"})
 	if err != nil {
 		return err
 	}
@@ -729,44 +742,13 @@ func (r *ScanReconciler) startReadOnlyHooks(scan *executionv1.Scan) error {
 	return nil
 }
 
-func allJobsCompleted(jobs *batch.JobList) jobCompletionType {
-	hasCompleted := true
-
-	for _, job := range jobs.Items {
-		if job.Status.Failed > 0 {
-			return failed
-		} else if job.Status.Succeeded == 0 {
-			hasCompleted = false
-		}
-	}
-
-	if hasCompleted {
-		return completed
-	}
-	return incomplete
-}
-
 func (r *ScanReconciler) checkIfReadOnlyHookIsCompleted(scan *executionv1.Scan) error {
 	ctx := context.Background()
-
-	// check if k8s job for scan was already created
-	var readOnlyHookJobs batch.JobList
-	if err := r.List(
-		ctx,
-		&readOnlyHookJobs,
-		client.InNamespace(scan.Namespace),
-		client.MatchingField(ownerKey, scan.Name),
-		client.MatchingLabels{
-			"experimental.securecodebox.io/job-type": "read-only-hook",
-		},
-	); err != nil {
-		r.Log.Error(err, "Unable to list child jobs")
+	readOnlyHookCompletion, err := r.checkIfJobIsCompleted(scan, client.MatchingLabels{"experimental.securecodebox.io/job-type": "read-only-hook"})
+	if err != nil {
 		return err
 	}
 
-	r.Log.V(9).Info("Got related jobs", "count", len(readOnlyHookJobs.Items))
-
-	readOnlyHookCompletion := allJobsCompleted(&readOnlyHookJobs)
 	if readOnlyHookCompletion == completed {
 		r.Log.V(7).Info("All ReadOnlyHooks have completed")
 		scan.Status.State = "Done"
@@ -1143,7 +1125,10 @@ func (r *ScanReconciler) executeReadAndWriteHooks(scan *executionv1.Scan) error 
 		})
 		return err
 	case executionv1.InProgress:
-		jobStatus, err := r.checkIfJobIsCompleted(nonCompletedHook.JobName, scan.Namespace)
+		jobStatus, err := r.checkIfJobIsCompleted(scan, client.MatchingLabels{
+			"experimental.securecodebox.io/job-type":  "read-and-write-hook",
+			"experimental.securecodebox.io/hook-name": nonCompletedHook.HookName,
+		})
 		if err != nil {
 			r.Log.Error(err, "Failed to check job status for ReadAndWrite Hook")
 			return err

--- a/operator/utils/truncatedname.go
+++ b/operator/utils/truncatedname.go
@@ -1,0 +1,11 @@
+package utils
+
+import "fmt"
+
+// TruncateName Ensures that the name used for a kubernetes object doesn't exceed the 63 char length limit. This actually cuts of anything after char 57, so that we can use the randomly generated suffix from k8s `generateName`.
+func TruncateName(name string) string {
+	if len(name) >= 57 {
+		return fmt.Sprintf("%s-", name[0:57])
+	}
+	return fmt.Sprintf("%s-", name)
+}

--- a/operator/utils/truncatedname_test.go
+++ b/operator/utils/truncatedname_test.go
@@ -1,0 +1,35 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+)
+
+type testData struct {
+	in  string
+	out string
+}
+
+func TestAbc(t *testing.T) {
+	var tests = []testData{
+		{
+			in:  "abc",
+			out: "abc-",
+		},
+		{
+			in:  "scan-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			out: "scan-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-",
+		},
+		{
+			in:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			out: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-",
+		},
+	}
+
+	for _, test := range tests {
+		actual := TruncateName(test.in)
+		if actual != test.out {
+			t.Error(fmt.Errorf("TruncateName(\"%s\") returned \"%s\", expected \"%s\"", test.in, actual, test.out))
+		}
+	}
+}

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -8,8 +8,8 @@ const k8sBatchApi = kc.makeApiClient(k8s.BatchV1Api);
 
 const namespace = "integration-tests";
 
-const sleep = duration =>
-  new Promise(resolve => setTimeout(resolve, duration * 1000));
+const sleep = (duration) =>
+  new Promise((resolve) => setTimeout(resolve, duration * 1000));
 
 async function deleteScan(name) {
   await k8sCRDApi.deleteNamespacedCustomObject(
@@ -30,21 +30,18 @@ async function getScan(name) {
     "scans",
     name
   );
-  return scan
+  return scan;
 }
 
 async function logJob(name) {
   try {
-    const { body: job } = await k8sBatchApi.readNamespacedJob(
-      name,
-      namespace,
-    );
-    console.log(`Job: '${name}' Spec:`)
-    console.dir(job.spec)
-    console.log(`Job: '${name}' Status:`)
-    console.dir(job.status)
+    const { body: job } = await k8sBatchApi.readNamespacedJob(name, namespace);
+    console.log(`Job: '${name}' Spec:`);
+    console.dir(job.spec);
+    console.log(`Job: '${name}' Status:`);
+    console.dir(job.status);
   } catch (error) {
-    console.info(`Job: '${name} not found.'`)
+    console.info(`Job: '${name} not found.'`);
   }
 }
 
@@ -61,12 +58,12 @@ async function scan(name, scanType, parameters = [], timeout = 180) {
     kind: "Scan",
     metadata: {
       // Use `generateName` instead of name to generate a random sufix and avoid name clashes
-      generateName: `${name}-`
+      generateName: `${name}-`,
     },
     spec: {
       scanType,
-      parameters
-    }
+      parameters,
+    },
   };
 
   const { body } = await k8sCRDApi.createNamespacedCustomObject(
@@ -82,23 +79,25 @@ async function scan(name, scanType, parameters = [], timeout = 180) {
   for (let i = 0; i < timeout; i++) {
     await sleep(1);
     const { status } = await getScan(actualName);
-    
+
     if (status && status.state === "Done") {
       await deleteScan(actualName);
       return status.findings;
     } else if (status && status.state === "Errored") {
       await deleteScan(actualName);
-      throw new Error(`Scan failed with description "${status.errorDescription}"`)
+      throw new Error(
+        `Scan failed with description "${status.errorDescription}"`
+      );
     }
   }
-  
-  console.error("Scan Timed out!")
+
+  console.error("Scan Timed out!");
 
   const scan = await getScan(actualName);
-  console.log("Last Scan State:")
-  console.dir(scan)
-  await logJob(`scan-${actualName}`)
-  await logJob(`parse-${actualName}`)
+  console.log("Last Scan State:");
+  console.dir(scan);
+  await logJob(`scan-${actualName}`);
+  await logJob(`parse-${actualName}`);
 
   throw new Error("timed out while waiting for scan results");
 }

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -33,15 +33,18 @@ async function getScan(name) {
   return scan;
 }
 
-async function logJob(name) {
+async function logJobs() {
   try {
-    const { body: job } = await k8sBatchApi.readNamespacedJob(name, namespace);
-    console.log(`Job: '${name}' Spec:`);
-    console.dir(job.spec);
-    console.log(`Job: '${name}' Status:`);
-    console.dir(job.status);
+    const { body: jobs } = await k8sBatchApi.listNamespacedJob(namespace);
+
+    for (const job of jobs.items) {
+      console.log(`Job: '${job.metadata.name}' Spec:`);
+      console.dir(job.spec);
+      console.log(`Job: '${job.metadata.name}' Status:`);
+      console.dir(job.status);
+    }
   } catch (error) {
-    console.info(`Job: '${name} not found.'`);
+    console.info(`Failed to list Jobs'`);
   }
 }
 
@@ -96,8 +99,7 @@ async function scan(name, scanType, parameters = [], timeout = 180) {
   const scan = await getScan(actualName);
   console.log("Last Scan State:");
   console.dir(scan);
-  await logJob(`scan-${actualName}`);
-  await logJob(`parse-${actualName}`);
+  await logJobs();
 
   throw new Error("timed out while waiting for scan results");
 }


### PR DESCRIPTION
Closes #21

This includes some notable changes as the name of the jobs is no not deterministic anymore.

Before this PR change: a scan called: `nmap-localhost`
Would always create the same jobs:
- `scan-nmap-localhost`
- `parse-nmap-localhost`
But the problem is this could result in to long job names (>= 63 chars).

After this PR these Jobs will always include a random element at the end and never be longer than 63 chars, like:
`scan-nmap-localhost-8j7fm`
`parse-nmap-localhost-54z2m`