### PR TITLE
Add Resource Limits to Scans

### DIFF
--- a/operator/controllers/execution/scan_controller.go
+++ b/operator/controllers/execution/scan_controller.go
@@ -31,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -439,6 +440,16 @@ func (r *ScanReconciler) startParser(scan *executionv1.Scan) error {
 								findingsUploadURL,
 							},
 							ImagePullPolicy: "Always",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("400m"),
+									corev1.ResourceMemory: resource.MustParse("200Mi"),
+								},
+							},
 						},
 					},
 					AutomountServiceAccountToken: &automountServiceAccountToken,
@@ -598,19 +609,16 @@ func (r *ScanReconciler) constructJobForScan(scan *executionv1.Scan, scanType *e
 				},
 			},
 		},
-		// TODO Assign sane default limits for lurcher
-		// Resources: corev1.ResourceRequirements{
-		// 	Limits: map[corev1.ResourceName]resource.Quantity{
-		// 		"": {
-		// 			Format: "",
-		// 		},
-		// 	},
-		// 	Requests: map[corev1.ResourceName]resource.Quantity{
-		// 		"": {
-		// 			Format: "",
-		// 		},
-		// 	},
-		// },
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("20Mi"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("100m"),
+				corev1.ResourceMemory: resource.MustParse("100Mi"),
+			},
+		},
 		VolumeMounts: []corev1.VolumeMount{
 			{
 				Name:      "scan-results",
@@ -1029,6 +1037,16 @@ func (r *ScanReconciler) createJobForHook(hook *executionv1.ScanCompletionHook, 
 							Args:            cliArgs,
 							Env:             append(hook.Spec.Env, standardEnvVars...),
 							ImagePullPolicy: "IfNotPresent",
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("200m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("400m"),
+									corev1.ResourceMemory: resource.MustParse("200Mi"),
+								},
+							},
 						},
 					},
 				},

--- a/scanners/amass/templates/amass-scan-type.yaml
+++ b/scanners/amass/templates/amass-scan-type.yaml
@@ -26,6 +26,8 @@ spec:
                 - name: "amass-config"
                   mountPath: "/amass/output/config.ini"
                   subPath: "config.ini"
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}
           volumes:
             - name: "amass-config"
               configMap:

--- a/scanners/amass/values.yaml
+++ b/scanners/amass/values.yaml
@@ -2,3 +2,6 @@ parserImage:
   registry: docker.io
   repository: scbexperimental/parser-amass
   tag: latest
+
+scannerJob:
+  resources: {}

--- a/scanners/kube-hunter/templates/kubehunter-scan-type.yaml
+++ b/scanners/kube-hunter/templates/kubehunter-scan-type.yaml
@@ -20,3 +20,5 @@ spec:
                 - '/wrapper.sh'
                 - '--report'
                 - 'json'
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}

--- a/scanners/kube-hunter/values.yaml
+++ b/scanners/kube-hunter/values.yaml
@@ -2,3 +2,6 @@ parserImage:
   registry: docker.io
   repository: scbexperimental/parser-kube-hunter
   tag: latest
+
+scannerJob:
+  resources: {}

--- a/scanners/nikto/templates/nikto-scan-type.yaml
+++ b/scanners/nikto/templates/nikto-scan-type.yaml
@@ -22,3 +22,5 @@ spec:
                 - '/wrapper.sh'
                 - '-o'
                 - '/home/securecodebox/nikto-results.json'
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}

--- a/scanners/nikto/values.yaml
+++ b/scanners/nikto/values.yaml
@@ -2,3 +2,6 @@ parserImage:
   registry: docker.io
   repository: scbexperimental/parser-nikto
   tag: latest
+
+scannerJob:
+  resources: {}

--- a/scanners/nmap/templates/nmap-scan-type.yaml
+++ b/scanners/nmap/templates/nmap-scan-type.yaml
@@ -17,3 +17,5 @@ spec:
             - name: nmap
               image: scbexperimental/nmap:7.80
               command: ["nmap", "-oX", "/home/securecodebox/nmap-results.xml"]
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}

--- a/scanners/nmap/values.yaml
+++ b/scanners/nmap/values.yaml
@@ -2,3 +2,6 @@ parserImage:
   registry: docker.io
   repository: scbexperimental/parser-nmap
   tag: latest
+
+scannerJob:
+  resources: {}

--- a/scanners/ssh_scan/templates/ssh-scan-scan-type.yaml
+++ b/scanners/ssh_scan/templates/ssh-scan-scan-type.yaml
@@ -20,3 +20,5 @@ spec:
                 - "/app/bin/ssh_scan"
                 - "--output"
                 - "/home/securecodebox/ssh-scan-results.json"
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}

--- a/scanners/ssh_scan/values.yaml
+++ b/scanners/ssh_scan/values.yaml
@@ -2,3 +2,6 @@ parserImage:
   registry: docker.io
   repository: scbexperimental/parser-ssh-scan
   tag: latest
+
+scannerJob:
+  resources: {}

--- a/scanners/sslyze/templates/sslyze-scan-type.yaml
+++ b/scanners/sslyze/templates/sslyze-scan-type.yaml
@@ -19,3 +19,5 @@ spec:
                 - 'sslyze'
                 - '--json_out'
                 - '/home/securecodebox/sslyze-results.json'
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}

--- a/scanners/sslyze/values.yaml
+++ b/scanners/sslyze/values.yaml
@@ -2,3 +2,6 @@ parserImage:
   registry: docker.io
   repository: scbexperimental/parser-sslyze
   tag: latest
+
+scannerJob:
+  resources: {}

--- a/scanners/test-scan/templates/test-scan-scan-type.yaml
+++ b/scanners/test-scan/templates/test-scan-scan-type.yaml
@@ -17,3 +17,5 @@ spec:
             - name: test-scan
               image: scbexperimental/test-scan:latest
               command: ["touch", "/home/securecodebox/hello-world.txt"]
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}

--- a/scanners/test-scan/values.yaml
+++ b/scanners/test-scan/values.yaml
@@ -2,3 +2,6 @@ parserImage:
   registry: docker.io
   repository: scbexperimental/parser-test-scan
   tag: latest
+
+scannerJob:
+  resources: {}

--- a/scanners/trivy/templates/trivy-scan-type.yaml
+++ b/scanners/trivy/templates/trivy-scan-type.yaml
@@ -24,3 +24,5 @@ spec:
                 - "json"
                 - "--output"
                 - "/home/securecodebox/trivy-results.json"
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}

--- a/scanners/trivy/values.yaml
+++ b/scanners/trivy/values.yaml
@@ -2,3 +2,6 @@ parserImage:
   registry: docker.io
   repository: scbexperimental/parser-trivy
   tag: latest
+
+scannerJob:
+  resources: {}

--- a/scanners/wpscan/templates/wpscan-scan-type.yaml
+++ b/scanners/wpscan/templates/wpscan-scan-type.yaml
@@ -22,3 +22,5 @@ spec:
                 - "/home/securecodebox/wpscan-results.json"
                 - "-f"
                 - json
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}

--- a/scanners/wpscan/values.yaml
+++ b/scanners/wpscan/values.yaml
@@ -2,3 +2,6 @@ parserImage:
   registry: docker.io
   repository: scbexperimental/parser-wpscan
   tag: latest
+
+scannerJob:
+  resources: {}

--- a/scanners/zap/templates/zap-scan-type.yaml
+++ b/scanners/zap/templates/zap-scan-type.yaml
@@ -26,6 +26,8 @@ spec:
               volumeMounts:
                 - mountPath: /zap/wrk
                   name: zap-workdir
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}
           volumes:
             - name: zap-workdir
               emptyDir: {}
@@ -58,6 +60,8 @@ spec:
               volumeMounts:
                 - mountPath: /zap/wrk
                   name: zap-workdir
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}
           volumes:
             - name: zap-workdir
               emptyDir: {}
@@ -90,6 +94,8 @@ spec:
               volumeMounts:
                 - mountPath: /zap/wrk
                   name: zap-workdir
+              resources:
+                {{- toYaml .Values.scannerJob.resources | nindent 16 }}
           volumes:
             - name: zap-workdir
               emptyDir: {}

--- a/scanners/zap/values.yaml
+++ b/scanners/zap/values.yaml
@@ -2,3 +2,6 @@ parserImage:
   registry: docker.io
   repository: scbexperimental/parser-zap
   tag: latest
+
+scannerJob:
+  resources: {}


### PR DESCRIPTION
Closes #36

This PR adds default limits and requests for the lurcher, parser and hooks.
These are currently static and cannot be changed without rebuilding the operator.

If this turns out to be ineffective this can be changed later.
Either by:

1. Allowing to change the default at install time via the Operators helm chart
2. Allow to override the default limits for parser and hooks in the their CRDs

The resources for the containers in which the actual scans are executed can be configured via helm.
The Charts don't provide a default value as recommended by helm (see note below):

> We usually recommend not to specify default resources and to leave this as a conscious choice for the user. This also increases chances charts run on environments with little resources, such as Minikube.