### PR TITLE
Scanner examples workaround

### DIFF
--- a/scanners/amass/README.md
+++ b/scanners/amass/README.md
@@ -21,10 +21,10 @@ helm upgrade --install amass ./scanners/amass/
 
 ## Examples
 
-A set of examples can be found in the [examples](./examples) folder.
+A set of examples can be found in the [examples](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/tree/master/scanners/amass/examples) folder.
 
-* Example *secureCodeBox.io* [scan](./examples/secureCodeBox.io/scan.yaml) and [findings](./examples/secureCodeBox.io/findings.yaml)
-* Example *example.com* [scan](./examples/secureCodeBox.io/scan.yaml) and [findings](./examples/secureCodeBox.io/findings.yaml)
+* Example *secureCodeBox.io* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/amass/examples/secureCodeBox.io/scan.yaml)
+* Example *example.com* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/amass/examples/example.com/scan.yaml)
 
 ## Configuration
 

--- a/scanners/kube-hunter/README.md
+++ b/scanners/kube-hunter/README.md
@@ -21,9 +21,9 @@ helm upgrade --install kube-hunter ./scanners/kube-hunter/
 
 ## Examples
 
-A set of examples can be found in the [examples](./examples) folder.
+A set of examples can be found in the [examples](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/tree/master/scanners/kube-hunter/examples) folder.
 
-* Example *in-cluster* [scan](./examples/in-cluster/scan.yaml) and [findings](./examples/in-cluster/findings.yaml)
+* Example *in-cluster* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/kube-hunter/examples/in-cluster/scan.yaml) and [findings](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/kube-hunter/examples/in-cluster/findings.json)
 
 ## Configuration
 

--- a/scanners/nikto/README.md
+++ b/scanners/nikto/README.md
@@ -21,9 +21,9 @@ helm upgrade --install nikto ./scanners/nikto/
 
 ## Examples
 
-A set of examples can be found in the [examples](./examples) folder.
+A set of examples can be found in the [examples](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/tree/master/scanners/nikto/examples) folder.
 
-* Example *secureCodeBox.io* [scan](./examples/secureCodeBox.io/scan.yaml) and [findings](./examples/secureCodeBox.io/findings.yaml)
+* Example *secureCodeBox.io* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/nikto/examples/secureCodeBox.io/scan.yaml)
 
 ## Configuration
 

--- a/scanners/nmap/README.md
+++ b/scanners/nmap/README.md
@@ -23,11 +23,11 @@ helm install nmap ./scanners/nmap/
 
 ## Examples
 
-A set of examples can be found in the [examples](./examples) folder.
+A set of examples can be found in the [examples](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/tree/master/scanners/nmap/examples) folder.
 
-* Example *local-network* [scan](./examples/local-network/scan.yaml) and [findings](./examples/local-network/findings.yaml)
-* Example *localhost* [scan](./examples/local-network/scan.yaml) and [findings](./examples/local-network/findings.yaml)
-* Example *scan.nmap.org* [scan](./examples/local-network/scan.yaml) and [findings](./examples/local-network/findings.yaml)
+* Example *local-network* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/nmap/examples/local-network/scan.yaml) and [findings](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/nmap/examples/local-network/findings.yaml)
+* Example *localhost* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/nmap/examples/localhost/scan.yaml) and [findings](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/nmap/examples/localhost/findings.yaml)
+* Example *scan.nmap.org* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/nmap/examples/scan.nmap.org/scan.yaml) and [findings](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/nmap/examples/scan.nmap.org/findings.yaml)
 
 ## Nmap Configuration
 

--- a/scanners/ssh_scan/README.md
+++ b/scanners/ssh_scan/README.md
@@ -22,10 +22,10 @@ helm upgrade --install ssh ./scanners/ssh_scan/
 
 ## Examples
 
-A set of examples can be found in the [examples](./examples) folder.
+A set of examples can be found in the [examples](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/tree/master/scanners/ssh_scan/examples) folder.
 
-* Example *example.com* [scan](./examples/example.com/scan.yaml) and [findings](./examples/example.com/findings.yaml)
-* Example *localhost* [scan](./examples/localhost/scan.yaml) and [findings](./examples/localhost/findings.yaml)
+* Example *example.com* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/ssh_scan/examples/example.com/scan.yaml)
+* Example *localhost* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/ssh_scan/examples/localhost/scan.yaml) and [findings](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/ssh_scan/examples/localhost/findings.yaml)
 
 ## Configuration
 

--- a/scanners/sslyze/README.md
+++ b/scanners/sslyze/README.md
@@ -19,10 +19,10 @@ helm upgrade --install sslyze ./scanners/sslyze/
 
 ## Examples
 
-A set of examples can be found in the [examples](./examples) folder.
+A set of examples can be found in the [examples](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/tree/master/scanners/sslyze/examples) folder.
 
-* Example *secureCodeBox.io* [scan](./examples/secureCodeBox.io/scan.yaml) and [findings](./examples/secureCodeBox.io/findings.yaml)
-* Example *example.com* [scan](./examples/example.com/scan.yaml) and [findings](./examples/example.com/findings.yaml)
+* Example *secureCodeBox.io* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/sslyze/examples/secureCodeBox.io/scan.yaml)
+* Example *example.com* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/sslyze/examples/example.com/scan.yaml)
 
 ## Configuration
 

--- a/scanners/trivy/README.md
+++ b/scanners/trivy/README.md
@@ -24,10 +24,10 @@ helm upgrade --install trivy ./scanners/trivy/
 
 ## Examples
 
-A set of examples can be found in the [examples](./examples) folder.
+A set of examples can be found in the [examples](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/tree/master/scanners/trivy/examples) folder.
 
-* Example *juice-shop* [scan](./examples/juice-shop/scan.yaml) and [findings](./examples/juice-shop/findings.yaml)
-* Example *mediawiki* [scan](./examples/mediawikip/scan.yaml) and [findings](./examples/mediawiki/findings.yaml)
+* Example *juice-shop* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/trivy/examples/juice-shop/scan.yaml) and [findings](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/trivy/examples/juice-shop/findings.yaml)
+* Example *mediawiki* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/trivy/examples/mediawiki/scan.yaml) and [findings](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/trivy/examples/mediawiki/findings.yaml)
 
 ## Configuration
 

--- a/scanners/wpscan/README.md
+++ b/scanners/wpscan/README.md
@@ -25,9 +25,9 @@ helm upgrade --install wpscan ./scanners/wpscan/
 
 ## Examples
 
-A set of examples can be found in the [examples](./examples) folder.
+A set of examples can be found in the [examples](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/tree/master/scanners/wpscan/examples) folder.
 
-* Example *example.com* [scan](./examples/secureCodeBox.io/scan.yaml) and [findings](./examples/secureCodeBox.io/findings.yaml)
+* Example *example.com* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/wpscan/examples/example.com/scan.yaml) and [findings](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/wpscan/examples/example.com/findings.yaml)
 
 ## Configuration
 

--- a/scanners/zap/README.md
+++ b/scanners/zap/README.md
@@ -23,10 +23,10 @@ helm upgrade --install zap ./scanners/zap/
 
 ## Examples
 
-A set of examples can be found in the [examples](./examples) folder.
+A set of examples can be found in the [examples](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/tree/master/scanners/zap/examples) folder.
 
-* Example *secureCodeBox.io* [scan](./examples/secureCodeBox.io/scan.yaml) and [findings](./examples/secureCodeBox.io/findings.yaml)
-* Example *example.com* [scan](./examples/example.com/scan.yaml) and [findings](./examples/example.com/findings.yaml)
+* Example *Juice Shop* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/zap/examples/demo-juice-shop-full-scan/scan.yaml) and [findings](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/zap/examples/demo-juice-shop-full-scan/findings.yaml)
+* Example *Pet Store* [scan](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/zap/examples/demo-petstore-api-scan/scan.yaml) and [findings](https://github.com/secureCodeBox/secureCodeBox-v2-alpha/blob/master/scanners/zap/examples/demo-petstore-api-scan/findings.yaml)
 
 ## Configuration
 


### PR DESCRIPTION
Scanner documentation links to example directories that are not parsed by GraphQL (yet). Temporary workaround changes links to absolute paths so that docs on website do not contain dead links.
- Change example links to absolute URLs so that they work on website
- Remove dead links