### PR TITLE
Update supported Kubernetes version range to include v1.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -316,7 +316,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        k8sVersion: ["1.18.6", "1.17.5", "1.16.9", "1.15.11"]
+        k8sVersion: ["1.19.0", "1.18.8", "1.17.5", "1.16.9"]
     steps:
       - uses: actions/checkout@master
       - name: "Start kind cluster"

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There is a German article about [Security DevOps – Angreifern (immer) einen Sc
 
 ### Prerequisites
 
-- kubernetes (last 4 major releases supported: `1.15`, `1.16`, `1.17` & `1.18`)
+- kubernetes (last 4 major releases supported: `1.16`, `1.17`, `1.18` & `1.19`,)
 
 ### Deployment (based on Helm)
 


### PR DESCRIPTION
Updated version range of supported Kubernetes Versions as 1.19 was just released.
Also updated versions used in integration tests to ensure it still works.