### PR TITLE
Ensure Helm Charts use corresponding Container Image Versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -336,9 +336,7 @@ jobs:
           # Install Operator using the images of the current commit
           helm -n securecodebox-system install securecodebox-operator ./operator/ --wait \
             --set="image.tag=sha-$(git rev-parse --short HEAD)" \
-            --set="image.digest=null" \
             --set="lurcher.image.tag=sha-$(git rev-parse --short HEAD)" \
-            --set="lurcher.image.digest=null"
       - name: "Inspect Operator"
         run: |
           echo "Deployment in namespace 'securecodebox-system'"

--- a/demo-apps/bodgeit/Chart.yaml
+++ b/demo-apps/bodgeit/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.0
+version: latest
 type: application
 appVersion: "v1.4.0"
 name: bodgeit
@@ -7,13 +7,12 @@ description: "The BodgeIt Store is a vulnerable web app which is aimed at people
 home: https://github.com/psiinon/bodgeit
 icon: https://scb-art.j12934.now.sh/bodgeit.png
 keywords:
-- vulnerable
-- webapp
-- demo
+  - vulnerable
+  - webapp
+  - demo
 sources:
-- https://github.com/secureCodeBox/helm
-- https://github.com/psiinon/bodgeit
+  - https://github.com/secureCodeBox/helm
+  - https://github.com/psiinon/bodgeit
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
-
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/demo-apps/dummy-ssh/Chart.yaml
+++ b/demo-apps/dummy-ssh/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.0
+version: latest
 type: application
 appVersion: "v1.0.0"
 name: dummy-ssh
@@ -7,11 +7,10 @@ description: "SSH Server for scan testing."
 home: https://wordpress.org
 icon: https://www.securecodebox.io/integrationIcons/SSH.svg
 keywords:
-- vulnerable
-- ssh
+  - vulnerable
+  - ssh
 sources:
-- https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/dummy-ssh
+  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/dummy-ssh
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
-
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/demo-apps/http-webhook/Chart.yaml
+++ b/demo-apps/http-webhook/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: latest
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/demo-apps/juice-shop/Chart.yaml
+++ b/demo-apps/juice-shop/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latestt
+version: latest
 appVersion: "v12.0.2"
 name: juice-shop
 description: "OWASP Juice Shop: Probably the most modern and sophisticated insecure web application"

--- a/demo-apps/juice-shop/Chart.yaml
+++ b/demo-apps/juice-shop/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.0
+version: latestt
 appVersion: "v12.0.2"
 name: juice-shop
 description: "OWASP Juice Shop: Probably the most modern and sophisticated insecure web application"
@@ -7,20 +7,20 @@ type: application
 home: https://owasp.org/www-project-juice-shop/
 icon: https://raw.githubusercontent.com/bkimminich/juice-shop/bdbcc0ea4484a2dd6b8ca243daa34c882129cdd4/frontend/src/assets/public/images/JuiceShop_Logo_400px.png
 keywords:
-- owasp
-- javascript
-- vulnerable
-- hacking
-- application-security
-- owasp-top-10
-- owasp-top-ten
-- pentesting
-- vulnapp
-- appsec
-- ctf
+  - owasp
+  - javascript
+  - vulnerable
+  - hacking
+  - application-security
+  - owasp-top-10
+  - owasp-top-ten
+  - pentesting
+  - vulnapp
+  - appsec
+  - ctf
 sources:
-- https://github.com/secureCodeBox/helm
-- https://github.com/bkimminich/juice-shop
+  - https://github.com/secureCodeBox/helm
+  - https://github.com/bkimminich/juice-shop
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/demo-apps/old-wordpress/Chart.yaml
+++ b/demo-apps/old-wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.0
+version: latesttt
 appVersion: "4.0"
 name: old-wordpress
 description: "Insecure & Outdated Wordpress Instance: Never expose it to the internet!"
@@ -7,11 +7,11 @@ type: application
 home: https://wordpress.org
 icon: https://s.w.org/style/images/about/WordPress-logotype-alternative.png
 keywords:
-- vulnerable
-- wordpress
+  - vulnerable
+  - wordpress
 sources:
-- https://github.com/secureCodeBox/helm
-- https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/old-wordpress
+  - https://github.com/secureCodeBox/helm
+  - https://github.com/secureCodeBox/secureCodeBox/tree/master/demo/old-wordpress
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/demo-apps/old-wordpress/Chart.yaml
+++ b/demo-apps/old-wordpress/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latesttt
+version: latest
 appVersion: "4.0"
 name: old-wordpress
 description: "Insecure & Outdated Wordpress Instance: Never expose it to the internet!"

--- a/demo-apps/swagger-petstore/Chart.yaml
+++ b/demo-apps/swagger-petstore/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.1.0
+version: latestt
 appVersion: "1.0.3"
 name: swagger-petstore
 description: "This is the sample petstore application"
@@ -7,11 +7,11 @@ type: application
 home: https://github.com/swagger-api/swagger-petstore
 icon: https://static1.smartbear.co/swagger/media/assets/images/swagger_logo.svg
 keywords:
-- swagger
-- openapi
+  - swagger
+  - openapi
 sources:
-- https://github.com/secureCodeBox/helm
-- https://github.com/swagger-api/swagger-petstore
+  - https://github.com/secureCodeBox/helm
+  - https://github.com/swagger-api/swagger-petstore
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/demo-apps/swagger-petstore/Chart.yaml
+++ b/demo-apps/swagger-petstore/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: latestt
+version: latest
 appVersion: "1.0.3"
 name: swagger-petstore
 description: "This is the sample petstore application"

--- a/hooks/declarative-subsequent-scans/Chart.yaml
+++ b/hooks/declarative-subsequent-scans/Chart.yaml
@@ -5,6 +5,6 @@ description: Starts possible subsequent security scans based on findings (e.g. o
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
+version: latest
 
 dependencies: []

--- a/hooks/declarative-subsequent-scans/Chart.yaml
+++ b/hooks/declarative-subsequent-scans/Chart.yaml
@@ -4,8 +4,7 @@ description: Starts possible subsequent security scans based on findings (e.g. o
 
 type: application
 
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
-
-appVersion: latest
 
 dependencies: []

--- a/hooks/declarative-subsequent-scans/templates/declerative-subsequent-scans-hook.yaml
+++ b/hooks/declarative-subsequent-scans/templates/declerative-subsequent-scans-hook.yaml
@@ -4,17 +4,5 @@ metadata:
   name: {{ include "declarative-subsequent-scans.fullname" . }}
 spec:
   type: ReadOnly
-  {{- if .Values.image.registry }}
-  {{- if .Values.image.digest }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-  {{- else }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-  {{- end }}
-  {{- else }}
-  {{- if .Values.image.digest }}
-  image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-  {{- else }}
-  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-  {{- end }}
-  {{- end }}
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
   serviceAccountName: declarative-combined-scans

--- a/hooks/declarative-subsequent-scans/values.yaml
+++ b/hooks/declarative-subsequent-scans/values.yaml
@@ -3,7 +3,6 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: docker.io
-  repository: scbexperimental/hook-declarative-subsequent-scans
-  tag: latest
-  digest: null
+  repository: docker.io/scbexperimental/hook-declarative-subsequent-scans
+  # image.tag - defaults to the charts version
+  tag: null

--- a/hooks/generic-webhook/Chart.yaml
+++ b/hooks/generic-webhook/Chart.yaml
@@ -5,6 +5,6 @@ description: Lets you send http webhooks after scans are completed
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
+version: latest
 
 dependencies: []

--- a/hooks/generic-webhook/Chart.yaml
+++ b/hooks/generic-webhook/Chart.yaml
@@ -4,8 +4,7 @@ description: Lets you send http webhooks after scans are completed
 
 type: application
 
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
-
-appVersion: latest
 
 dependencies: []

--- a/hooks/generic-webhook/templates/webhook-hook.yaml
+++ b/hooks/generic-webhook/templates/webhook-hook.yaml
@@ -4,11 +4,7 @@ metadata:
   name: {{ include "generic-webhook.fullname" . }}
 spec:
   type: ReadOnly
-  {{- if .Values.image.digest }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-  {{- else }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-  {{- end }}
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
   env:
     - name: WEBHOOK_URL
       value: {{ .Values.webhookUrl | quote }}

--- a/hooks/generic-webhook/values.yaml
+++ b/hooks/generic-webhook/values.yaml
@@ -5,7 +5,6 @@
 webhookUrl: "http://example.com"
 
 image:
-  registry: docker.io
-  repository: scbexperimental/generic-webhook
-  tag: latest
-  digest: null
+  repository: docker.io/scbexperimental/generic-webhook
+  # image.tag - defaults to the charts version
+  tag: null

--- a/hooks/imperative-subsequent-scans/Chart.yaml
+++ b/hooks/imperative-subsequent-scans/Chart.yaml
@@ -5,6 +5,6 @@ description: Starts possible subsequent security scans based on findings (e.g. o
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
+version: latest
 
 dependencies: []

--- a/hooks/imperative-subsequent-scans/Chart.yaml
+++ b/hooks/imperative-subsequent-scans/Chart.yaml
@@ -4,8 +4,7 @@ description: Starts possible subsequent security scans based on findings (e.g. o
 
 type: application
 
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
-
-appVersion: 0.1.0
 
 dependencies: []

--- a/hooks/imperative-subsequent-scans/templates/imperative-subsequent-scans-hook.yaml
+++ b/hooks/imperative-subsequent-scans/templates/imperative-subsequent-scans-hook.yaml
@@ -4,19 +4,7 @@ metadata:
   name: {{ .Release.Name }}
 spec:
   type: ReadOnly
-  {{- if .Values.image.registry }}
-  {{- if .Values.image.digest }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-  {{- else }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-  {{- end }}
-  {{- else }}
-  {{- if .Values.image.digest }}
-  image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-  {{- else }}
-  image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-  {{- end }}
-  {{- end }}
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"
   serviceAccountName: imperative-combined-scans
   env:
     - name: CASCADE_AMASS_NMAP

--- a/hooks/imperative-subsequent-scans/values.yaml
+++ b/hooks/imperative-subsequent-scans/values.yaml
@@ -17,7 +17,6 @@ cascade:
   nmapZapBaseline: false
 
 image:
-  registry: docker.io
-  repository: scbexperimental/hook-imperative-subsequent-scans
-  tag: latest
-  digest: null
+  repository: docker.io/scbexperimental/hook-imperative-subsequent-scans
+  # image.tag - defaults to the charts version
+  tag: null

--- a/hooks/persistence-elastic/Chart.yaml
+++ b/hooks/persistence-elastic/Chart.yaml
@@ -4,9 +4,10 @@ description: The elastic persistence provider persists secureCodeBox findings in
 
 type: application
 
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
 
-appVersion: latest
+appVersion: 7.6.1
 
 dependencies:
   - name: elasticsearch

--- a/hooks/persistence-elastic/Chart.yaml
+++ b/hooks/persistence-elastic/Chart.yaml
@@ -5,7 +5,7 @@ description: The elastic persistence provider persists secureCodeBox findings in
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
+version: latest
 
 appVersion: 7.6.1
 

--- a/hooks/persistence-elastic/templates/persistence-provider.yaml
+++ b/hooks/persistence-elastic/templates/persistence-provider.yaml
@@ -6,12 +6,7 @@ metadata:
     type: Structured
 spec:
   type: ReadOnly
-  image: "scbexperimental/persistence-elastic:latest"
-  {{- if .Values.image.digest }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-  {{- else }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-  {{- end }}
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
   env:
     - name: ELASTICSEARCH_INDEX_PREFIX
       value: {{ .Values.indexPrefix | quote }}

--- a/hooks/persistence-elastic/values.yaml
+++ b/hooks/persistence-elastic/values.yaml
@@ -3,10 +3,9 @@
 # Declare variables to be passed into your templates.
 
 image:
-  registry: docker.io
-  repository: scbexperimental/persistence-elastic
-  tag: latest
-  digest: null
+  repository: docker.io/scbexperimental/persistence-elastic
+  # image.tag - defaults to the charts version
+  tag: null
 
 # Define a specific index prefix
 indexPrefix: "scbv2"

--- a/hooks/update-field/Chart.yaml
+++ b/hooks/update-field/Chart.yaml
@@ -4,8 +4,7 @@ description: Lets you add or override a field to every finding
 
 type: application
 
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
-
-appVersion: latest
 
 dependencies: []

--- a/hooks/update-field/Chart.yaml
+++ b/hooks/update-field/Chart.yaml
@@ -5,6 +5,6 @@ description: Lets you add or override a field to every finding
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
+version: latest
 
 dependencies: []

--- a/hooks/update-field/templates/update-field-hook.yaml
+++ b/hooks/update-field/templates/update-field-hook.yaml
@@ -4,11 +4,7 @@ metadata:
   name: {{ .Release.Name }}
 spec:
   type: ReadAndWrite
-  {{- if .Values.image.digest }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-  {{- else }}
-  image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-  {{- end }}
+  image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
   env:
     - name: ATTRIBUTE_NAME
       value: {{ .Values.attribute.name | quote }}

--- a/hooks/update-field/values.yaml
+++ b/hooks/update-field/values.yaml
@@ -7,7 +7,6 @@ attribute:
   value: my-own-category
 
 image:
-  registry: docker.io
-  repository: scbexperimental/update-field
-  tag: latest
-  digest: null
+  repository: docker.io/scbexperimental/update-field
+  # image.tag - defaults to the charts version
+  tag: null

--- a/operator/Chart.yaml
+++ b/operator/Chart.yaml
@@ -5,7 +5,7 @@ description: secureCodeBox Operator to automate the execution of security scans 
 type: application
 
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: v2.0.0-alpha1
+version: latest
 
 dependencies:
   - name: minio

--- a/operator/Chart.yaml
+++ b/operator/Chart.yaml
@@ -4,13 +4,8 @@ description: secureCodeBox Operator to automate the execution of security scans 
 
 type: application
 
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-version: 0.2.0
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
-appVersion: 1.18.0
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
+version: v2.0.0-alpha1
 
 dependencies:
   - name: minio

--- a/operator/templates/manager/manager.yaml
+++ b/operator/templates/manager/manager.yaml
@@ -20,11 +20,7 @@ spec:
             - /manager
           args:
             - --enable-leader-election
-          {{- if .Values.image.digest }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}@{{ .Values.image.digest }}"
-          {{- else }}
-          image: "{{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-          {{- end }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           name: manager
           env:
@@ -74,14 +70,9 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.s3.keySecret }}
                   key: secretkey
-            {{- end }}
-            {{- if .Values.lurcher.image.digest }}
+            {{- end }}          
             - name: LURCHER_IMAGE
-              value: "{{ .Values.lurcher.image.registry }}/{{ .Values.lurcher.image.repository }}@{{ .Values.lurcher.image.digest }}"
-            {{- else }}
-            - name: LURCHER_IMAGE
-              value: "{{ .Values.lurcher.image.registry }}/{{ .Values.lurcher.image.repository }}:{{ .Values.lurcher.image.tag }}"
-            {{- end }}
+              value: "{{ .Values.lurcher.image.repository }}:{{ .Values.lurcher.image.tag | default .Chart.Version }}"
             - name: LURCHER_PULL_POLICY
               value: {{ .Values.lurcher.image.pullPolicy }}
           resources:

--- a/operator/values.yaml
+++ b/operator/values.yaml
@@ -6,18 +6,16 @@
 telemetryEnabled: true
 
 image:
-  registry: docker.io
-  repository: scbexperimental/operator
-  tag: latest
-  digest: null
+  repository: docker.io/scbexperimental/operator
+  # image.tag -- defaults to the charts version
+  tag: null
   pullPolicy: Always
 
 lurcher:
   image:
-    registry: docker.io
-    repository: scbexperimental/lurcher
+    repository: docker.io/scbexperimental/lurcher
+    # lurcher.image.tag -- defaults to the charts version
     tag: null
-    digest: "sha256:0e9f18f85809fb8c042543657d340949db14e81fc727bf9fab4421befd317850"
     pullPolicy: IfNotPresent
 
 minio:

--- a/scanners/amass/Chart.yaml
+++ b/scanners/amass/Chart.yaml
@@ -3,6 +3,7 @@ name: amass
 description: A Helm chart for the Amass security scanner that integrates with the secureCodeBox.
 
 type: application
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
 appVersion: 3.10.3
 

--- a/scanners/amass/Chart.yaml
+++ b/scanners/amass/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the Amass security scanner that integrates with th
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
+version: latest
 appVersion: 3.10.3
 
 keywords:

--- a/scanners/amass/templates/amass-parse-definition.yaml
+++ b/scanners/amass/templates/amass-parse-definition.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "amass-jsonl"
 spec:
   handlesResultsType: amass-jsonl
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/amass/values.yaml
+++ b/scanners/amass/values.yaml
@@ -1,7 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-amass
-  tag: latest
+  repository: docker.io/scbexperimental/parser-amass
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}

--- a/scanners/kube-hunter/Chart.yaml
+++ b/scanners/kube-hunter/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for the kube-hunter security scanner that integrates w
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
-appVersion: 0.1.0
+version: latest
+appVersion: v0.3.0
 
 keywords:
   - security

--- a/scanners/kube-hunter/Chart.yaml
+++ b/scanners/kube-hunter/Chart.yaml
@@ -3,18 +3,19 @@ name: kube-hunter
 description: A Helm chart for the kube-hunter security scanner that integrates with the secureCodeBox.
 
 type: application
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
 appVersion: 0.1.0
 
 keywords:
-- security
-- kube-hunter
-- scanner
-- secureCodeBox
+  - security
+  - kube-hunter
+  - scanner
+  - secureCodeBox
 home: https://www.securecodebox.io/scanners/kube-hunter
 icon: https://www.securecodebox.io/scannerIcons/kube-hunter.svg
 sources:
-- https://github.com/secureCodeBox/secureCodeBox
+  - https://github.com/secureCodeBox/secureCodeBox
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/scanners/kube-hunter/templates/kube-hunter-parse-definition.yaml
+++ b/scanners/kube-hunter/templates/kube-hunter-parse-definition.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "kube-hunter-json"
 spec:
   handlesResultsType: kube-hunter-json
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/kube-hunter/values.yaml
+++ b/scanners/kube-hunter/values.yaml
@@ -1,7 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-kube-hunter
-  tag: latest
+  repository: docker.io/scbexperimental/parser-kube-hunter
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}

--- a/scanners/ncrack/Chart.yaml
+++ b/scanners/ncrack/Chart.yaml
@@ -3,18 +3,19 @@ name: ncrack
 description: A Helm chart for the NCRACK security Scanner that integrates with the secureCodeBox.
 
 type: application
-version: 0.1.0
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
+version: latest
 appVersion: 0.7
 
 keywords:
-- security
-- ncrack
-- scanner
-- secureCodeBox
+  - security
+  - ncrack
+  - scanner
+  - secureCodeBox
 home: https://www.securecodebox.io/scanners/ncrack
 icon: https://www.securecodebox.io/scannerIcons/Ncrack.svg
 sources:
-- https://github.com/secureCodeBox/secureCodeBox
+  - https://github.com/secureCodeBox/secureCodeBox
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/scanners/ncrack/templates/ncrack-parse-definition.yaml
+++ b/scanners/ncrack/templates/ncrack-parse-definition.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "ncrack-xml"
 spec:
   handlesResultsType: ncrack-xml
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/ncrack/values.yaml
+++ b/scanners/ncrack/values.yaml
@@ -1,8 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-ncrack
-  tag: latest
+  repository: docker.io/scbexperimental/parser-ncrack
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}
-

--- a/scanners/nikto/Chart.yaml
+++ b/scanners/nikto/Chart.yaml
@@ -4,7 +4,8 @@ description: A Helm chart for the Nikto security scanner that integrates with th
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
+version: latest
+# appVersion - Nikto doesn't really version its releases
 appVersion: latest
 
 keywords:

--- a/scanners/nikto/Chart.yaml
+++ b/scanners/nikto/Chart.yaml
@@ -3,18 +3,19 @@ name: nikto
 description: A Helm chart for the Nikto security scanner that integrates with the secureCodeBox.
 
 type: application
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
 appVersion: latest
 
 keywords:
-- security
-- nikto
-- scanner
-- secureCodeBox
+  - security
+  - nikto
+  - scanner
+  - secureCodeBox
 home: https://www.securecodebox.io/scanners/nikto
 icon: https://www.securecodebox.io/scannerIcons/Nikto.svg
 sources:
-- https://github.com/secureCodeBox/secureCodeBox
+  - https://github.com/secureCodeBox/secureCodeBox
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/scanners/nikto/templates/nikto-parse-definition.yaml
+++ b/scanners/nikto/templates/nikto-parse-definition.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "nikto-json"
 spec:
   handlesResultsType: nikto-json
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/nikto/values.yaml
+++ b/scanners/nikto/values.yaml
@@ -1,7 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-nikto
-  tag: latest
+  repository: docker.io/scbexperimental/parser-nikto
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}

--- a/scanners/nmap/Chart.yaml
+++ b/scanners/nmap/Chart.yaml
@@ -3,18 +3,19 @@ name: nmap
 description: A Helm chart for the NMAP security Scanner that integrates with the secureCodeBox.
 
 type: application
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
 appVersion: 7.80-r2
 
 keywords:
-- security
-- nmap
-- scanner
-- secureCodeBox
+  - security
+  - nmap
+  - scanner
+  - secureCodeBox
 home: https://www.securecodebox.io/scanners/nmap
 icon: https://www.securecodebox.io/scannerIcons/Nmap.svg
 sources:
-- https://github.com/secureCodeBox/secureCodeBox
+  - https://github.com/secureCodeBox/secureCodeBox
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/scanners/nmap/Chart.yaml
+++ b/scanners/nmap/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the NMAP security Scanner that integrates with the
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
+version: latest
 appVersion: 7.80-r2
 
 keywords:

--- a/scanners/nmap/templates/nmap-parse-definition.yaml
+++ b/scanners/nmap/templates/nmap-parse-definition.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "nmap-xml"
 spec:
   handlesResultsType: nmap-xml
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/nmap/values.yaml
+++ b/scanners/nmap/values.yaml
@@ -1,7 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-nmap
-  tag: latest
+  repository: docker.io/scbexperimental/parser-nmap
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}

--- a/scanners/ssh_scan/Chart.yaml
+++ b/scanners/ssh_scan/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for the SSH_Scan security scanner that integrates with
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
-appVersion: latest
+version: latest
+appVersion: "0.0.43"
 
 keywords:
   - security

--- a/scanners/ssh_scan/Chart.yaml
+++ b/scanners/ssh_scan/Chart.yaml
@@ -3,19 +3,19 @@ name: ssh-scan
 description: A Helm chart for the SSH_Scan security scanner that integrates with the secureCodeBox.
 
 type: application
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
 appVersion: latest
 
 keywords:
-- security
-- ssh
-- scanner
-- secureCodeBox
+  - security
+  - ssh
+  - scanner
+  - secureCodeBox
 home: https://www.securecodebox.io/scanners/ssh
 icon: https://www.securecodebox.io/scannerIcons/SSH.svg
 sources:
-- https://github.com/secureCodeBox/secureCodeBox
+  - https://github.com/secureCodeBox/secureCodeBox
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
-
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/scanners/ssh_scan/templates/ssh-scan-parse-definition.yaml
+++ b/scanners/ssh_scan/templates/ssh-scan-parse-definition.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "ssh-scan-json"
 spec:
   handlesResultsType: ssh-scan-json
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/ssh_scan/values.yaml
+++ b/scanners/ssh_scan/values.yaml
@@ -1,7 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-ssh-scan
-  tag: latest
+  repository: docker.io/scbexperimental/parser-ssh-scan
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}

--- a/scanners/sslyze/Chart.yaml
+++ b/scanners/sslyze/Chart.yaml
@@ -3,18 +3,19 @@ name: sslyze
 description: A Helm chart for the SSLyze security scanner that integrates with the secureCodeBox.
 
 type: application
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
 appVersion: 3.0.6
 
 keywords:
-- security
-- ssl
-- scanner
-- secureCodeBox
+  - security
+  - ssl
+  - scanner
+  - secureCodeBox
 home: https://www.securecodebox.io/scanners/sslyze
 icon: https://www.securecodebox.io/scannerIcons/SSLyze.svg
 sources:
-- https://github.com/secureCodeBox/secureCodeBox
+  - https://github.com/secureCodeBox/secureCodeBox
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/scanners/sslyze/Chart.yaml
+++ b/scanners/sslyze/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for the SSLyze security scanner that integrates with t
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
-appVersion: 3.0.6
+version: latest
+appVersion: v3.0.6
 
 keywords:
   - security

--- a/scanners/sslyze/templates/sslyze-parse-definition.yaml
+++ b/scanners/sslyze/templates/sslyze-parse-definition.yaml
@@ -1,7 +1,7 @@
-apiVersion: 'execution.experimental.securecodebox.io/v1'
+apiVersion: "execution.experimental.securecodebox.io/v1"
 kind: ParseDefinition
 metadata:
-  name: 'sslyze-json'
+  name: "sslyze-json"
 spec:
   handlesResultsType: sslyze-json
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/sslyze/values.yaml
+++ b/scanners/sslyze/values.yaml
@@ -1,7 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-sslyze
-  tag: latest
+  repository: docker.io/scbexperimental/parser-sslyze
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}

--- a/scanners/test-scan/Chart.yaml
+++ b/scanners/test-scan/Chart.yaml
@@ -3,17 +3,17 @@ name: test-scan
 description: A Helm chart to test the secureCodeBox operator
 
 type: application
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
-appVersion: 0.1.0
 
 keywords:
-- security
-- scanner
-- secureCodeBox
-- integrationTest
-- test
+  - security
+  - scanner
+  - secureCodeBox
+  - integrationTest
+  - test
 sources:
-- https://github.com/secureCodeBox/secureCodeBox
+  - https://github.com/secureCodeBox/secureCodeBox
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/scanners/test-scan/Chart.yaml
+++ b/scanners/test-scan/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart to test the secureCodeBox operator
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
+version: latest
 
 keywords:
   - security

--- a/scanners/test-scan/templates/test-scan-parse-definition.yaml
+++ b/scanners/test-scan/templates/test-scan-parse-definition.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "test-txt"
 spec:
   handlesResultsType: test-txt
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/test-scan/values.yaml
+++ b/scanners/test-scan/values.yaml
@@ -1,7 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-test-scan
-  tag: latest
+  repository: docker.io/scbexperimental/parser-test-scan
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}

--- a/scanners/trivy/Chart.yaml
+++ b/scanners/trivy/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for the trivy security scanner that integrates with th
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
-appVersion: latest
+version: latest
+appVersion: v0.6.0
 
 keywords:
   - security

--- a/scanners/trivy/Chart.yaml
+++ b/scanners/trivy/Chart.yaml
@@ -3,6 +3,7 @@ name: trivy
 description: A Helm chart for the trivy security scanner that integrates with the secureCodeBox.
 
 type: application
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
 appVersion: latest
 

--- a/scanners/trivy/templates/trivy-parse-definition.yaml
+++ b/scanners/trivy/templates/trivy-parse-definition.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "trivy-json"
 spec:
   handlesResultsType: trivy-json
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/trivy/values.yaml
+++ b/scanners/trivy/values.yaml
@@ -1,7 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-trivy
-  tag: latest
+  repository: docker.io/scbexperimental/parser-trivy
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}

--- a/scanners/wpscan/Chart.yaml
+++ b/scanners/wpscan/Chart.yaml
@@ -3,19 +3,20 @@ name: wpscan
 description: A Helm chart for the WordPress security scanner that integrates with the secureCodeBox.
 
 type: application
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
 appVersion: latest
 
 keywords:
-- security
-- wpscan
-- wordpress
-- scanner
-- secureCodeBox
+  - security
+  - wpscan
+  - wordpress
+  - scanner
+  - secureCodeBox
 home: https://www.securecodebox.io/scanners/wpscan
 icon: https://www.securecodebox.io/scannerIcons/WPScan.svg
 sources:
-- https://github.com/secureCodeBox/scanner-infrastructure-wpscan
+  - https://github.com/secureCodeBox/scanner-infrastructure-wpscan
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/scanners/wpscan/Chart.yaml
+++ b/scanners/wpscan/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for the WordPress security scanner that integrates wit
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
+version: latest
 appVersion: latest
 
 keywords:

--- a/scanners/wpscan/templates/wpscan-parse-definition.yaml
+++ b/scanners/wpscan/templates/wpscan-parse-definition.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "wpscan-json"
 spec:
   handlesResultsType: wpscan-json
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/wpscan/values.yaml
+++ b/scanners/wpscan/values.yaml
@@ -1,7 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-wpscan
-  tag: latest
+  repository: docker.io/scbexperimental/parser-wpscan
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}

--- a/scanners/zap/Chart.yaml
+++ b/scanners/zap/Chart.yaml
@@ -3,20 +3,20 @@ name: zap
 description: A Helm chart for the OWASP ZAP security scanner that integrates with the secureCodeBox.
 
 type: application
+# version - gets automatically set to the secureCodeBox release version when the helm charts gets published
 version: 0.1.0
 appVersion: latest
 
 keywords:
-- security
-- Zap
-- OWASP
-- scanner
-- secureCodeBox
+  - security
+  - Zap
+  - OWASP
+  - scanner
+  - secureCodeBox
 home: https://www.securecodebox.io/scanners/zap
 icon: https://www.securecodebox.io/scannerIcons/ZAP.svg
 sources:
-- https://github.com/secureCodeBox/secureCodeBox
+  - https://github.com/secureCodeBox/secureCodeBox
 maintainers:
-- name: iteratec GmbH
-  email: security@iteratec.com
-
+  - name: iteratec GmbH
+    email: security@iteratec.com

--- a/scanners/zap/Chart.yaml
+++ b/scanners/zap/Chart.yaml
@@ -4,8 +4,8 @@ description: A Helm chart for the OWASP ZAP security scanner that integrates wit
 
 type: application
 # version - gets automatically set to the secureCodeBox release version when the helm charts gets published
-version: 0.1.0
-appVersion: latest
+version: latest
+appVersion: v2.9.0
 
 keywords:
   - security

--- a/scanners/zap/templates/zap-parse-definition.yaml
+++ b/scanners/zap/templates/zap-parse-definition.yaml
@@ -4,4 +4,4 @@ metadata:
   name: "zap-json"
 spec:
   handlesResultsType: zap-json
-  image: "{{ .Values.parserImage.registry }}/{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag }}"
+  image: "{{ .Values.parserImage.repository }}:{{ .Values.parserImage.tag | default .Chart.Version }}"

--- a/scanners/zap/values.yaml
+++ b/scanners/zap/values.yaml
@@ -1,7 +1,7 @@
 parserImage:
-  registry: docker.io
-  repository: scbexperimental/parser-zap
-  tag: latest
+  repository: docker.io/scbexperimental/parser-zap
+  # parserImage.tag - defaults to the charts version
+  tag: null
 
 scannerJob:
   resources: {}


### PR DESCRIPTION
This PR ensures, as an example, that if a Chart is installed in version 2.0.42 it will always use the corresponding 2.0.42 docker images tags to ensure compatibility. 

- Removed `appVersion` from Charts where there isn't a versioned external dependency, e.g. a scanner or database used in the chart.
- Charts use `latest` as the default version. The actual version is set to the version of the release when the chart is published. This ensures that local installs use the "cutting edge" version while normal installs can use stable versions.
- Simplified handling and templating of the images in the chart. If you still want to use the images digest you can still pass is via the tag e.g. by setting `helm install securecodebox-operator secureCodeBox/operator --set "image.tag=latest@sha256:83415c2181e84d444b05a36cf055c21ba6878237a8936cd85990c773617e841b"`
