### PR TITLE
Add Integration Tests for ZAP

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -426,7 +426,7 @@ jobs:
           helm -n integration-tests install ssh-scan ./scanners/ssh_scan/ --set="parserImage.tag=sha-$(git rev-parse --short HEAD)"
           cd tests/integration/
           npx jest --ci --color ssh-scan
-      - name: "ssh-scan Integration Tests"
+      - name: "zap Integration Tests"
         run: |
           helm -n integration-tests install zap ./scanners/zap/ --set="parserImage.tag=sha-$(git rev-parse --short HEAD)"
           cd tests/integration/

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -403,6 +403,9 @@ jobs:
         run: |
           # Install dummy-ssh app
           helm -n demo-apps install dummy-ssh ./demo-apps/dummy-ssh/ --wait
+          # Install plain nginx server
+          kubectl create deployment --image nginx:alpine nginx --namespace demo-apps
+          kubectl expose deployment nginx --port 80 --namespace demo-apps
       - name: "nmap Integration Tests"
         run: |
           helm -n integration-tests install nmap ./scanners/nmap/ --set="parserImage.tag=sha-$(git rev-parse --short HEAD)"
@@ -423,6 +426,11 @@ jobs:
           helm -n integration-tests install ssh-scan ./scanners/ssh_scan/ --set="parserImage.tag=sha-$(git rev-parse --short HEAD)"
           cd tests/integration/
           npx jest --ci --color ssh-scan
+      - name: "ssh-scan Integration Tests"
+        run: |
+          helm -n integration-tests install zap ./scanners/zap/ --set="parserImage.tag=sha-$(git rev-parse --short HEAD)"
+          cd tests/integration/
+          npx jest --ci --color zap
       - name: Inspect Post Failure
         if: failure()
         run: |

--- a/scanners/amass/templates/amass-scan-type.yaml
+++ b/scanners/amass/templates/amass-scan-type.yaml
@@ -10,7 +10,9 @@ spec:
     location: "/home/securecodebox/amass-results.jsonl"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         spec:
           restartPolicy: OnFailure

--- a/scanners/amass/values.yaml
+++ b/scanners/amass/values.yaml
@@ -4,6 +4,7 @@ parserImage:
   tag: latest
 
 scannerJob:
+  ttlSecondsAfterFinished: null
   resources: {}
 # scannerJob:
 #   resources:

--- a/scanners/kube-hunter/templates/kubehunter-scan-type.yaml
+++ b/scanners/kube-hunter/templates/kubehunter-scan-type.yaml
@@ -8,7 +8,9 @@ spec:
     location: '/home/securecodebox/kube-hunter-results.json'
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         spec:
           restartPolicy: Never

--- a/scanners/kube-hunter/values.yaml
+++ b/scanners/kube-hunter/values.yaml
@@ -4,4 +4,5 @@ parserImage:
   tag: latest
 
 scannerJob:
+  ttlSecondsAfterFinished: null
   resources: {}

--- a/scanners/ncrack/templates/ncrack-scan-type.yaml
+++ b/scanners/ncrack/templates/ncrack-scan-type.yaml
@@ -8,7 +8,9 @@ spec:
     location: "/home/securecodebox/ncrack-results.xml"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       backoffLimit: 3
       template:
         spec:

--- a/scanners/ncrack/values.yaml
+++ b/scanners/ncrack/values.yaml
@@ -4,5 +4,5 @@ parserImage:
   tag: latest
 
 scannerJob:
+  ttlSecondsAfterFinished: null
   resources: {}
-

--- a/scanners/nikto/templates/nikto-scan-type.yaml
+++ b/scanners/nikto/templates/nikto-scan-type.yaml
@@ -8,7 +8,9 @@ spec:
     location: '/home/securecodebox/nikto-results.json'
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         spec:
           restartPolicy: Never

--- a/scanners/nikto/values.yaml
+++ b/scanners/nikto/values.yaml
@@ -4,6 +4,7 @@ parserImage:
   tag: latest
 
 scannerJob:
+  ttlSecondsAfterFinished: null
   resources: {}
 # scannerJob:
 #   resources:

--- a/scanners/nmap/templates/nmap-scan-type.yaml
+++ b/scanners/nmap/templates/nmap-scan-type.yaml
@@ -8,7 +8,9 @@ spec:
     location: "/home/securecodebox/nmap-results.xml"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       backoffLimit: 3
       template:
         spec:

--- a/scanners/nmap/values.yaml
+++ b/scanners/nmap/values.yaml
@@ -4,6 +4,7 @@ parserImage:
   tag: latest
 
 scannerJob:
+  ttlSecondsAfterFinished: null
   resources: {}
 # scannerJob:
 #   resources:

--- a/scanners/ssh_scan/templates/ssh-scan-scan-type.yaml
+++ b/scanners/ssh_scan/templates/ssh-scan-scan-type.yaml
@@ -9,7 +9,9 @@ spec:
     location: "/home/securecodebox/ssh-scan-results.json"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         spec:
           restartPolicy: OnFailure

--- a/scanners/ssh_scan/values.yaml
+++ b/scanners/ssh_scan/values.yaml
@@ -4,6 +4,7 @@ parserImage:
   tag: latest
 
 scannerJob:
+  ttlSecondsAfterFinished: null
   resources: {}
 # scannerJob:
 #   resources:

--- a/scanners/sslyze/templates/sslyze-scan-type.yaml
+++ b/scanners/sslyze/templates/sslyze-scan-type.yaml
@@ -8,7 +8,9 @@ spec:
     location: '/home/securecodebox/sslyze-results.json'
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         spec:
           restartPolicy: OnFailure

--- a/scanners/sslyze/values.yaml
+++ b/scanners/sslyze/values.yaml
@@ -4,6 +4,7 @@ parserImage:
   tag: latest
 
 scannerJob:
+  ttlSecondsAfterFinished: null
   resources: {}
 # scannerJob:
 #   resources:

--- a/scanners/test-scan/templates/test-scan-scan-type.yaml
+++ b/scanners/test-scan/templates/test-scan-scan-type.yaml
@@ -8,7 +8,9 @@ spec:
     location: "/home/securecodebox/hello-world.txt"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       backoffLimit: 3
       template:
         spec:

--- a/scanners/test-scan/values.yaml
+++ b/scanners/test-scan/values.yaml
@@ -4,6 +4,7 @@ parserImage:
   tag: latest
 
 scannerJob:
+  ttlSecondsAfterFinished: null
   resources: {}
 # scannerJob:
 #   resources:

--- a/scanners/trivy/templates/trivy-scan-type.yaml
+++ b/scanners/trivy/templates/trivy-scan-type.yaml
@@ -9,7 +9,9 @@ spec:
     location: "/home/securecodebox/trivy-results.json"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         spec:
           restartPolicy: OnFailure

--- a/scanners/trivy/values.yaml
+++ b/scanners/trivy/values.yaml
@@ -4,6 +4,7 @@ parserImage:
   tag: latest
 
 scannerJob:
+  ttlSecondsAfterFinished: null
   resources: {}
 # scannerJob:
 #   resources:

--- a/scanners/wpscan/templates/wpscan-scan-type.yaml
+++ b/scanners/wpscan/templates/wpscan-scan-type.yaml
@@ -9,7 +9,9 @@ spec:
     location: "/home/securecodebox/wpscan-results.json"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         spec:
           restartPolicy: OnFailure

--- a/scanners/wpscan/values.yaml
+++ b/scanners/wpscan/values.yaml
@@ -4,6 +4,7 @@ parserImage:
   tag: latest
 
 scannerJob:
+  ttlSecondsAfterFinished: null
   resources: {}
 # scannerJob:
 #   resources:

--- a/scanners/zap/templates/zap-scan-type.yaml
+++ b/scanners/zap/templates/zap-scan-type.yaml
@@ -16,7 +16,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: zap-baseline
-              image: owasp/zap2docker-stable:2.9.0
+              image: owasp/zap2docker-weekly:w2020-09-15
               command:
                 - "zap-baseline.py"
                 # Force Zap to always return a zero exit code. k8s would otherwise try to restart zap.
@@ -52,7 +52,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: zap-api-scan
-              image: owasp/zap2docker-weekly:w2020-09-08
+              image: owasp/zap2docker-weekly:w2020-09-15
               command:
                 - "zap-api-scan.py"
                 # Force Zap to always return a zero exit code. k8s would otherwise try to restart zap.
@@ -88,7 +88,7 @@ spec:
           restartPolicy: Never
           containers:
             - name: zap-full-scan
-              image: owasp/zap2docker-weekly:w2020-09-08
+              image: owasp/zap2docker-weekly:w2020-09-15
               command:
                 - "zap-full-scan.py"
                 # Force Zap to always return a zero exit code. k8s would otherwise try to restart zap.

--- a/scanners/zap/templates/zap-scan-type.yaml
+++ b/scanners/zap/templates/zap-scan-type.yaml
@@ -8,7 +8,9 @@ spec:
     location: "/home/securecodebox/zap-results.json"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         spec:
           restartPolicy: Never
@@ -42,7 +44,9 @@ spec:
     location: "/home/securecodebox/zap-results.json"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         spec:
           restartPolicy: Never
@@ -76,7 +80,9 @@ spec:
     location: "/home/securecodebox/zap-results.json"
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 10
+      {{- if .Values.scannerJob.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.scannerJob.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         spec:
           restartPolicy: Never

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -122,10 +122,10 @@ async function scan(name, scanType, parameters = [], timeout = 180) {
     const { status } = await getScan(actualName);
 
     if (status && status.state === "Done") {
-      await deleteScan(actualName);
       // Wait a couple seconds to give kubernetes more time to update the fields
       await sleep(2);
       const { status } = await getScan(actualName);
+      await deleteScan(actualName);
       return status.findings;
     } else if (status && status.state === "Errored") {
       console.error("Scan Errored");

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -34,7 +34,7 @@ async function getScan(name) {
 }
 
 async function displayAllLogsForJob(jobName) {
-  console.log(`Listing logs for Job ${jobName}:`);
+  console.log(`Listing logs for Job '${jobName}':`);
   const {
     body: { items: pods },
   } = await k8sPodsApi.listNamespacedPod(
@@ -46,7 +46,15 @@ async function displayAllLogsForJob(jobName) {
     `job-name=${jobName}`
   );
 
+  if (pods.length === 0) {
+    console.log(`No Pods found for Job '${jobName}'`);
+  }
+
   for (const pod of pods) {
+    console.log(
+      `Listing logs for Job '${jobName}' > Pod '${pod.metadata.name}':`
+    );
+
     for (const container of pod.spec.containers) {
       const response = await k8sPodsApi.readNamespacedPodLog(
         pod.metadata.name,
@@ -67,14 +75,14 @@ async function logJobs() {
 
     for (const job of jobs.items) {
       console.log(`Job: '${job.metadata.name}' Spec:`);
-      console.dir(job.spec);
+      console.log(JSON.stringify(job.spec, null, 2));
       console.log(`Job: '${job.metadata.name}' Status:`);
-      console.dir(job.status);
+      console.log(JSON.stringify(job.status, null, 2));
 
       await displayAllLogsForJob(job.metadata.name);
     }
   } catch (error) {
-    console.info(`Failed to list Jobs'`);
+    console.error(`Failed to list Jobs'`);
   }
 }
 

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -124,6 +124,9 @@ async function scan(name, scanType, parameters = [], timeout = 180) {
 
     if (status && status.state === "Done") {
       await deleteScan(actualName);
+      // Wait a couple seconds to give kubernetes more time to update the fields
+      await sleep(2000);
+      const { status } = await getScan(actualName);
       return status.findings;
     } else if (status && status.state === "Errored") {
       console.error("Scan Errored");

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -82,7 +82,8 @@ async function logJobs() {
       await displayAllLogsForJob(job.metadata.name);
     }
   } catch (error) {
-    console.error(`Failed to list Jobs'`);
+    console.error("Failed to list Jobs");
+    console.error(error);
   }
 }
 

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -56,13 +56,19 @@ async function displayAllLogsForJob(jobName) {
     );
 
     for (const container of pod.spec.containers) {
-      const response = await k8sPodsApi.readNamespacedPodLog(
-        pod.metadata.name,
-        namespace,
-        container.name
-      );
-      console.log(`Container ${container.name}:`);
-      console.log(response.body);
+      try {
+        const response = await k8sPodsApi.readNamespacedPodLog(
+          pod.metadata.name,
+          namespace,
+          container.name
+        );
+        console.log(`Container ${container.name}:`);
+        console.log(response.body);
+      } catch (exception) {
+        console.error(
+          `Failed to display logs of container ${container.name}: ${exception.body.message}`
+        );
+      }
     }
   }
 }

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -38,7 +38,7 @@ async function displayAllLogsForJob(jobName) {
   const {
     body: { items: pods },
   } = await k8sPodsApi.listNamespacedPod(
-    "default",
+    namespace,
     true,
     undefined,
     undefined,
@@ -58,7 +58,7 @@ async function displayAllLogsForJob(jobName) {
     for (const container of pod.spec.containers) {
       const response = await k8sPodsApi.readNamespacedPodLog(
         pod.metadata.name,
-        "default",
+        namespace,
         container.name
       );
       console.log(`Container ${container.name}:`);

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -5,6 +5,7 @@ kc.loadFromDefault();
 
 const k8sCRDApi = kc.makeApiClient(k8s.CustomObjectsApi);
 const k8sBatchApi = kc.makeApiClient(k8s.BatchV1Api);
+const k8sPodsApi = kc.makeApiClient(k8s.CoreV1Api);
 
 const namespace = "integration-tests";
 
@@ -33,19 +34,56 @@ async function getScan(name) {
   return scan;
 }
 
+async function displayAllLogsForJob(jobName) {
+  console.log(`Listing logs for Job ${jobName}:`);
+  const {
+    body: { items: pods },
+  } = await k8sPodsApi.listNamespacedPod(
+    "default",
+    true,
+    undefined,
+    undefined,
+    undefined,
+    `job-name=${jobName}`
+  );
+
+  for (const pod of pods) {
+    for (const container of pod.spec.containers) {
+      const response = await k8sPodsApi.readNamespacedPodLog(
+        pod.metadata.name,
+        "default",
+        container.name
+      );
+      console.log(`Container ${container.name}:`);
+      console.log(response.body);
+    }
+  }
+}
+
 async function logJobs() {
   try {
     const { body: jobs } = await k8sBatchApi.listNamespacedJob(namespace);
+
+    console.log("Logging spec & status of jobs in namespace");
 
     for (const job of jobs.items) {
       console.log(`Job: '${job.metadata.name}' Spec:`);
       console.dir(job.spec);
       console.log(`Job: '${job.metadata.name}' Status:`);
       console.dir(job.status);
+
+      await displayAllLogsForJob(job.metadata.name);
     }
   } catch (error) {
     console.info(`Failed to list Jobs'`);
   }
+}
+
+async function disasterRecovery(scanName) {
+  const scan = await getScan(scanName);
+  console.error("Last Scan State:");
+  console.dir(scan);
+  await logJobs();
 }
 
 /**
@@ -54,7 +92,7 @@ async function logJobs() {
  * @param {string} scanType type of the scan. Must match the name of a ScanType CRD
  * @param {string[]} parameters cli argument to be passed to the scanner
  * @param {number} timeout in seconds
- * @returns {scan.findings} returns findings { categories, severities, count } 
+ * @returns {scan.findings} returns findings { categories, severities, count }
  */
 async function scan(name, scanType, parameters = [], timeout = 180) {
   const scanDefinition = {
@@ -88,19 +126,16 @@ async function scan(name, scanType, parameters = [], timeout = 180) {
       await deleteScan(actualName);
       return status.findings;
     } else if (status && status.state === "Errored") {
-      await deleteScan(actualName);
+      console.error("Scan Errored");
+      await disasterRecovery(actualName);
+
       throw new Error(
         `Scan failed with description "${status.errorDescription}"`
       );
     }
   }
-
   console.error("Scan Timed out!");
-
-  const scan = await getScan(actualName);
-  console.log("Last Scan State:");
-  console.dir(scan);
-  await logJobs();
+  await disasterRecovery(actualName);
 
   throw new Error("timed out while waiting for scan results");
 }

--- a/tests/integration/helpers.js
+++ b/tests/integration/helpers.js
@@ -9,8 +9,7 @@ const k8sPodsApi = kc.makeApiClient(k8s.CoreV1Api);
 
 const namespace = "integration-tests";
 
-const sleep = (duration) =>
-  new Promise((resolve) => setTimeout(resolve, duration * 1000));
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms * 1000));
 
 async function deleteScan(name) {
   await k8sCRDApi.deleteNamespacedCustomObject(
@@ -125,7 +124,7 @@ async function scan(name, scanType, parameters = [], timeout = 180) {
     if (status && status.state === "Done") {
       await deleteScan(actualName);
       // Wait a couple seconds to give kubernetes more time to update the fields
-      await sleep(2000);
+      await sleep(2);
       const { status } = await getScan(actualName);
       return status.findings;
     } else if (status && status.state === "Errored") {

--- a/tests/integration/scanner/zap.test.js
+++ b/tests/integration/scanner/zap.test.js
@@ -1,0 +1,25 @@
+const { scan } = require("../helpers");
+
+test(
+  "zap baseline scan against a plain nginx container should only find couple findings",
+  async () => {
+    const { categories, severities } = await scan(
+      "zap-nginx-baseline",
+      "zap-baseline",
+      ["-t", "http://nginx.demo-apps.svc"],
+      60 * 4
+    );
+
+    expect(categories).toMatchObject({
+      "Content Security Policy (CSP) Header Not Set": 1,
+      'Server Leaks Version Information via "Server" HTTP Response Header Field': 1,
+      "X-Content-Type-Options Header Missing": 1,
+      "X-Frame-Options Header Not Set": 1,
+    });
+    expect(severities).toMatchObject({
+      low: 3,
+      medium: 1,
+    });
+  },
+  5 * 60 * 1000
+);


### PR DESCRIPTION
This PR adds integration tests for the ZAP integration.

While adding these i've made some other improvements to improve the stability and debuggability of the tests:

- Made `ttlSecondsAfterFinished` property on scanJobs configurable. Kind seems to already have the ttlAfterFinished controller running even thought its still an alpha feature. When this is enable its harder to log print logs of failing scanner containers as they might already be deleted.
- Test helper will now print out logs of the scan container when it failed. This allows to easier debug why a test is failing.
- Reduce test flakyness by giving the k8s api server more time (2 seconds) before fetching the final state of the finished scan. This reduces the likeliness that the tests fetch inconsistent scan state.
- Swtich out all ZAP images to weekly releases (also the baseline scanType), as the 2.9.0 doesn't run on `containerd` cluster.