### PR TITLE
Fixing CodeClimate Integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
       - name: "Run tests & publish code coverage"
         uses: paambaati/codeclimate-action@v2.6.0
         env:
-          CC_TEST_REPORTER_ID: 80b305e484240da8cecbd1d017dfb365d3ee7f4508b5ed8fd9e9348efd286406
+          CC_TEST_REPORTER_ID: 545b7af20f13dc58a3284275828532a26d89a8e90c8f276fb54a23d78bae7a19
         with:
           coverageCommand: npm test -- --ci --colors --coverage
   operator:


### PR DESCRIPTION
Due to the last repo renaming the CodeClimate integration was broken. To reintegrate CodeClimate again we need to adjust the test report id in our pipeline.