### PR TITLE
Cleanup Unused / Badly named CRD Attributes

### DIFF
--- a/operator/apis/execution/v1/parsedefinition_types.go
+++ b/operator/apis/execution/v1/parsedefinition_types.go
@@ -29,10 +29,10 @@ type ParseDefinitionSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
 
-	// Foo is an example field of ParseDefinition. Edit ParseDefinition_types.go to remove/update
-	HandlesResultsType string                        `json:"handlesResultsType,omitempty"`
-	Image              string                        `json:"image,omitempty"`
-	ImagePullSecrets   []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+	// Image is the reference to the parser container image which ca transform the raw scan report into findings
+	Image string `json:"image,omitempty"`
+	// ImagePullSecrets used to access private parser images
+	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
 }
 
 // ParseDefinitionStatus defines the observed state of ParseDefinition
@@ -42,7 +42,6 @@ type ParseDefinitionStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:printcolumn:name="Handles Type",type=string,JSONPath=`.spec.handlesResultsType`,description="Which result file type the parser is able to handle"
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image`,description="Scanner Container Image"
 
 // ParseDefinition is the Schema for the parsedefinitions API

--- a/operator/apis/execution/v1/scheduledscan_types.go
+++ b/operator/apis/execution/v1/scheduledscan_types.go
@@ -29,13 +29,13 @@ type ScheduledScanSpec struct {
 	// Important: Run "make" to regenerate code after modifying this file
 
 	// Interval describes how often the scan should be repeated
-	// Examples: '12h', '7d', '30m' (only days, hours and minutes supported, specified as integers)
+	// Examples: '12h', '30m'
 	Interval metav1.Duration `json:"interval"`
 
-	// HistoryLimit determines how many past Scans will be kept until the oldest one will be delted, defaults to 3. When set to 0 Scans will be deleted directly after completion
-	HistoryLimit int64 `json:"historyLimit,omitempty"`
+	// SuccessfulJobsHistoryLimit determines how many past Scans will be kept until the oldest one will be delted, defaults to 3. When set to 0 Scans will be deleted directly after completion
+	SuccessfulJobsHistoryLimit int64 `json:"successfulJobsHistoryLimit,omitempty"`
 
-	// Foo is an example field of ScheduledScan. Edit ScheduledScan_types.go to remove/update
+	// ScanSpec describes the scan which should be started regularly
 	ScanSpec *ScanSpec `json:"scanSpec"`
 }
 

--- a/operator/apis/execution/v1/scheduledscan_types.go
+++ b/operator/apis/execution/v1/scheduledscan_types.go
@@ -32,8 +32,11 @@ type ScheduledScanSpec struct {
 	// Examples: '12h', '30m'
 	Interval metav1.Duration `json:"interval"`
 
-	// SuccessfulJobsHistoryLimit determines how many past Scans will be kept until the oldest one will be delted, defaults to 3. When set to 0 Scans will be deleted directly after completion
-	SuccessfulJobsHistoryLimit int64 `json:"successfulJobsHistoryLimit,omitempty"`
+	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:Minimum=0
+
+	// SuccessfulJobsHistoryLimit determines how many past Scans will be kept until the oldest one will be deleted, defaults to 3. When set to 0, Scans will be deleted directly after completion
+	SuccessfulJobsHistoryLimit *int32 `json:"successfulJobsHistoryLimit,omitempty"`
 
 	// ScanSpec describes the scan which should be started regularly
 	ScanSpec *ScanSpec `json:"scanSpec"`

--- a/operator/apis/execution/v1/zz_generated.deepcopy.go
+++ b/operator/apis/execution/v1/zz_generated.deepcopy.go
@@ -564,6 +564,11 @@ func (in *ScheduledScanList) DeepCopyObject() runtime.Object {
 func (in *ScheduledScanSpec) DeepCopyInto(out *ScheduledScanSpec) {
 	*out = *in
 	out.Interval = in.Interval
+	if in.SuccessfulJobsHistoryLimit != nil {
+		in, out := &in.SuccessfulJobsHistoryLimit, &out.SuccessfulJobsHistoryLimit
+		*out = new(int32)
+		**out = **in
+	}
 	if in.ScanSpec != nil {
 		in, out := &in.ScanSpec, &out.ScanSpec
 		*out = new(ScanSpec)

--- a/operator/config/crd/bases/execution.securecodebox.io_parsedefinitions.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_parsedefinitions.yaml
@@ -9,10 +9,6 @@ metadata:
   name: parsedefinitions.execution.securecodebox.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.handlesResultsType
-    description: Which result file type the parser is able to handle
-    name: Handles Type
-    type: string
   - JSONPath: .spec.image
     description: Scanner Container Image
     name: Image
@@ -44,13 +40,12 @@ spec:
         spec:
           description: ParseDefinitionSpec defines the desired state of ParseDefinition
           properties:
-            handlesResultsType:
-              description: Foo is an example field of ParseDefinition. Edit ParseDefinition_types.go
-                to remove/update
-              type: string
             image:
+              description: Image is the reference to the parser container image which
+                ca transform the raw scan report into findings
               type: string
             imagePullSecrets:
+              description: ImagePullSecrets used to access private parser images
               items:
                 description: LocalObjectReference contains enough information to let
                   you locate the referenced object inside the same namespace.

--- a/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
@@ -226,9 +226,10 @@ spec:
               type: object
             successfulJobsHistoryLimit:
               description: SuccessfulJobsHistoryLimit determines how many past Scans
-                will be kept until the oldest one will be delted, defaults to 3. When
-                set to 0 Scans will be deleted directly after completion
-              format: int64
+                will be kept until the oldest one will be deleted, defaults to 3.
+                When set to 0, Scans will be deleted directly after completion
+              format: int32
+              minimum: 0
               type: integer
           required:
           - interval

--- a/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/config/crd/bases/execution.securecodebox.io_scheduledscans.yaml
@@ -59,20 +59,12 @@ spec:
         spec:
           description: ScheduledScanSpec defines the desired state of ScheduledScan
           properties:
-            historyLimit:
-              description: HistoryLimit determines how many past Scans will be kept
-                until the oldest one will be delted, defaults to 3. When set to 0
-                Scans will be deleted directly after completion
-              format: int64
-              type: integer
             interval:
               description: 'Interval describes how often the scan should be repeated
-                Examples: ''12h'', ''7d'', ''30m'' (only days, hours and minutes supported,
-                specified as integers)'
+                Examples: ''12h'', ''30m'''
               type: string
             scanSpec:
-              description: Foo is an example field of ScheduledScan. Edit ScheduledScan_types.go
-                to remove/update
+              description: ScanSpec describes the scan which should be started regularly
               properties:
                 cascades:
                   description: A label selector is a label query over a set of resources.
@@ -232,6 +224,12 @@ spec:
                 scanType:
                   type: string
               type: object
+            successfulJobsHistoryLimit:
+              description: SuccessfulJobsHistoryLimit determines how many past Scans
+                will be kept until the oldest one will be delted, defaults to 3. When
+                set to 0 Scans will be deleted directly after completion
+              format: int64
+              type: integer
           required:
           - interval
           - scanSpec

--- a/operator/config/samples/execution_v1_parsedefinition.yaml
+++ b/operator/config/samples/execution_v1_parsedefinition.yaml
@@ -3,5 +3,4 @@ kind: ParseDefinition
 metadata:
   name: "nmap-xml"
 spec:
-  handlesResultsType: nmap-xml
   image: securecodebox/nmap-parser

--- a/operator/config/samples/execution_v1_scheduledscan.yaml
+++ b/operator/config/samples/execution_v1_scheduledscan.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scheduled-nmap-localhost
 spec:
   interval: 1m
-  historyLimit: 2
+  successfulJobsHistoryLimit: 2
   scanSpec:
     scanType: "nmap"
     parameters:

--- a/operator/controllers/execution/scheduledscan_controller.go
+++ b/operator/controllers/execution/scheduledscan_controller.go
@@ -96,8 +96,13 @@ func (r *ScheduledScanReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	// Delete Old Scans when exceeding the history limit
+	var historyLimit int32 = 3
+	if scheduledScan.Spec.SuccessfulJobsHistoryLimit != nil {
+		historyLimit = *scheduledScan.Spec.SuccessfulJobsHistoryLimit
+	}
+
 	for i, scan := range completedScans {
-		if int64(i) >= int64(len(completedScans))-scheduledScan.Spec.SuccessfulJobsHistoryLimit {
+		if int32(i) >= int32(len(completedScans))-historyLimit {
 			break
 		}
 		if err := r.Delete(ctx, &scan, client.PropagationPolicy(metav1.DeletePropagationBackground)); (err) != nil {

--- a/operator/controllers/execution/scheduledscan_controller.go
+++ b/operator/controllers/execution/scheduledscan_controller.go
@@ -97,7 +97,7 @@ func (r *ScheduledScanReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 
 	// Delete Old Scans when exceeding the history limit
 	for i, scan := range completedScans {
-		if int64(i) >= int64(len(completedScans))-scheduledScan.Spec.HistoryLimit {
+		if int64(i) >= int64(len(completedScans))-scheduledScan.Spec.SuccessfulJobsHistoryLimit {
 			break
 		}
 		if err := r.Delete(ctx, &scan, client.PropagationPolicy(metav1.DeletePropagationBackground)); (err) != nil {

--- a/operator/crds/execution.securecodebox.io_parsedefinitions.yaml
+++ b/operator/crds/execution.securecodebox.io_parsedefinitions.yaml
@@ -9,10 +9,6 @@ metadata:
   name: parsedefinitions.execution.securecodebox.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.handlesResultsType
-    description: Which result file type the parser is able to handle
-    name: Handles Type
-    type: string
   - JSONPath: .spec.image
     description: Scanner Container Image
     name: Image
@@ -44,13 +40,12 @@ spec:
         spec:
           description: ParseDefinitionSpec defines the desired state of ParseDefinition
           properties:
-            handlesResultsType:
-              description: Foo is an example field of ParseDefinition. Edit ParseDefinition_types.go
-                to remove/update
-              type: string
             image:
+              description: Image is the reference to the parser container image which
+                ca transform the raw scan report into findings
               type: string
             imagePullSecrets:
+              description: ImagePullSecrets used to access private parser images
               items:
                 description: LocalObjectReference contains enough information to let
                   you locate the referenced object inside the same namespace.

--- a/operator/crds/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/crds/execution.securecodebox.io_scheduledscans.yaml
@@ -226,9 +226,10 @@ spec:
               type: object
             successfulJobsHistoryLimit:
               description: SuccessfulJobsHistoryLimit determines how many past Scans
-                will be kept until the oldest one will be delted, defaults to 3. When
-                set to 0 Scans will be deleted directly after completion
-              format: int64
+                will be kept until the oldest one will be deleted, defaults to 3.
+                When set to 0, Scans will be deleted directly after completion
+              format: int32
+              minimum: 0
               type: integer
           required:
           - interval

--- a/operator/crds/execution.securecodebox.io_scheduledscans.yaml
+++ b/operator/crds/execution.securecodebox.io_scheduledscans.yaml
@@ -59,20 +59,12 @@ spec:
         spec:
           description: ScheduledScanSpec defines the desired state of ScheduledScan
           properties:
-            historyLimit:
-              description: HistoryLimit determines how many past Scans will be kept
-                until the oldest one will be delted, defaults to 3. When set to 0
-                Scans will be deleted directly after completion
-              format: int64
-              type: integer
             interval:
               description: 'Interval describes how often the scan should be repeated
-                Examples: ''12h'', ''7d'', ''30m'' (only days, hours and minutes supported,
-                specified as integers)'
+                Examples: ''12h'', ''30m'''
               type: string
             scanSpec:
-              description: Foo is an example field of ScheduledScan. Edit ScheduledScan_types.go
-                to remove/update
+              description: ScanSpec describes the scan which should be started regularly
               properties:
                 cascades:
                   description: A label selector is a label query over a set of resources.
@@ -232,6 +224,12 @@ spec:
                 scanType:
                   type: string
               type: object
+            successfulJobsHistoryLimit:
+              description: SuccessfulJobsHistoryLimit determines how many past Scans
+                will be kept until the oldest one will be delted, defaults to 3. When
+                set to 0 Scans will be deleted directly after completion
+              format: int64
+              type: integer
           required:
           - interval
           - scanSpec


### PR DESCRIPTION
While writing docs for the CRDs I found some attributes which weren't ideal:

## `historyLimit` on ScheduledScans:

Inconsistent with Naming on Kubernetes CronJobs. On ChronJobs its called `successfulJobsHistoryLimit` and `failedJobsHistoryLimit`. "Our `historyLimit` currently only applies to successfulJobs Jobs which makes this naming really confusing as the name would suggest it applies to any job.

This change allows us to introduce failedJobsHistoryLimit in the future.

## `handlesResultsType` in the ParseDefinition

This isn't used anymore. Instead the name of the ParseDefinition is used. This PR removes this to avoid confusion.